### PR TITLE
Do not crash on '404 not found' response

### DIFF
--- a/actiapi/v3.py
+++ b/actiapi/v3.py
@@ -3,7 +3,7 @@
 See https://github.com/actigraph/CentrePoint3APIDocumentation.
 """
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Literal
 
 import requests
 
@@ -53,6 +53,7 @@ class ActiGraphClientV3(ActiGraphClient):
         study_id: int,
         start: Optional[str] = None,
         end: Optional[str] = None,
+        data_format: Literal["avro", "csv"] = "avro",
     ) -> List[str]:
         """Return download URLs to raw AVRO files.
 
@@ -66,14 +67,18 @@ class ActiGraphClientV3(ActiGraphClient):
             Start timestamp string in ISO8601 format
         end:
             End timestamp string in ISO8601 format
+        data_format:
+            Raw data file format; avro (default) or csv.
         """
+        assert data_format in ("avro", "csv")
+
         token = self._get_access_token(
             "DataAccess",
         )
 
         request_string = (
             f"/dataaccess/v3/files/studies/{study_id}/subjects/{user}"
-            f"/raw-accelerometer?fileFormat=avro"
+            f"/raw-accelerometer?fileFormat={data_format}"
         )
         if start is not None:
             request_string += f"&startDate={start}"

--- a/actiapi/v3.py
+++ b/actiapi/v3.py
@@ -176,7 +176,9 @@ class ActiGraphClientV3(ActiGraphClient):
                 self.BASE_URL + paginated_request,
                 headers=headers,
             )
-            reply = response.json()
+            reply = validate_response(response)
+            if reply is None:
+                break
             total_count = reply["totalCount"]
 
             for item in reply["items"]:
@@ -188,3 +190,12 @@ class ActiGraphClientV3(ActiGraphClient):
             logging.error("No raw data found.")
             return []
         return results
+
+
+def validate_response(response):
+    if response.status_code == 404:
+        logging.warning("404 Not Found!")
+        result = None
+    else:
+        result = response.json()
+    return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,13 @@ def v3_study_id():
 def v3_client(v3_access_key, v3_secret_key):
     client = ActiGraphClientV3(v3_access_key, v3_secret_key)
     return client
+
+
+@pytest.fixture(scope="session")
+def response_404():
+    """Simulate an Http response with status code 404."""
+
+    class Response:
+        status_code = 404
+
+    return Response()

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1,6 +1,14 @@
+from actiapi.v3 import validate_response
+
+
 def test_metadata(v3_client, v3_study_id):
     metadata = v3_client.get_study_metadata(v3_study_id)
     assert len(metadata) == 2
+
+
+def test_validate_empty_response(response_404):
+    result = validate_response(response_404)
+    assert result is None
 
 
 def test_minutes(v3_client, v3_study_id):


### PR DESCRIPTION
If the API response is "404 not found" the program used to proceed and crashed later on without an obvious error message.
This PR is stopping the program and reporting a warning in such a case.

Also, this PR allows for getting the raw data in csv format.